### PR TITLE
bugfix(centroid): fix precision loss from long to double

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ gradle-app.setting
 .vscode
 
 .settings/
+.project

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ gradle-app.setting
 ### VisualStudioCode template
 .vscode
 
+.settings/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please note that [geo_shape data type](https://www.elastic.co/guide/en/elasticse
 ### Install
 
 Install plugin with:
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-geoclustering/releases/download/v8.19.4.0/geopoint-clustering-aggregation-8.19.4.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-geoclustering/releases/download/v8.19.6.0/geopoint-clustering-aggregation-8.19.6.0.zip`
 
 
 ### Quickstart

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please note that [geo_shape data type](https://www.elastic.co/guide/en/elasticse
 ### Install
 
 Install plugin with:
-`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-geoclustering/releases/download/v8.19.6.0/geopoint-clustering-aggregation-8.19.6.0.zip`
+`./bin/elasticsearch-plugin install https://github.com/opendatasoft/elasticsearch-aggregation-geoclustering/releases/download/v8.19.6.1/geopoint-clustering-aggregation-8.19.6.1.zip`
 
 
 ### Quickstart

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-es_version = 8.19.4
-plugin_version = 8.19.4.0
+es_version = 8.19.6
+plugin_version = 8.19.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 es_version = 8.19.6
-plugin_version = 8.19.6.0
+plugin_version = 8.19.6.1

--- a/src/main/java/com/opendatasoft/elasticsearch/search/aggregations/bucket/geopointclustering/GeoPointClusteringAggregationBuilder.java
+++ b/src/main/java/com/opendatasoft/elasticsearch/search/aggregations/bucket/geopointclustering/GeoPointClusteringAggregationBuilder.java
@@ -301,7 +301,7 @@ public class GeoPointClusteringAggregationBuilder extends ValuesSourceAggregatio
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.ZERO;
+        return TransportVersion.zero();
     }
 
     public static void registerAggregators(ValuesSourceRegistry.Builder builder) {

--- a/src/main/java/com/opendatasoft/elasticsearch/search/aggregations/bucket/geopointclustering/InternalGeoPointClustering.java
+++ b/src/main/java/com/opendatasoft/elasticsearch/search/aggregations/bucket/geopointclustering/InternalGeoPointClustering.java
@@ -1,5 +1,11 @@
 package com.opendatasoft.elasticsearch.search.aggregations.bucket.geopointclustering;
 
+import static java.util.Collections.unmodifiableList;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
@@ -16,30 +22,30 @@ import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+public class InternalGeoPointClustering
+    extends InternalMultiBucketAggregation<
+        InternalGeoPointClustering,
+        InternalGeoPointClustering.Bucket
+    >
+    implements GeoPointClustering {
 
-import static java.util.Collections.unmodifiableList;
-
-public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
-    InternalGeoPointClustering,
-    InternalGeoPointClustering.Bucket> implements GeoPointClustering {
-
-    static class Bucket extends InternalMultiBucketAggregation.InternalBucketWritable
-        implements
-            GeoPointClustering.Bucket,
-            Comparable<Bucket> {
+    static class Bucket
+        extends InternalMultiBucketAggregation.InternalBucketWritable
+        implements GeoPointClustering.Bucket, Comparable<Bucket> {
 
         protected long hashAsLong;
         protected GeoPoint centroid;
         protected long docCount;
-        protected InternalAggregations aggregations;  // sub-aggregations for this bucket
+        protected InternalAggregations aggregations; // sub-aggregations for this bucket
         protected boolean visited = false;
         protected Set<Long> geohashesList;
 
-        Bucket(long hashAsLong, GeoPoint centroid, long docCount, InternalAggregations aggregations) {
+        Bucket(
+            long hashAsLong,
+            GeoPoint centroid,
+            long docCount,
+            InternalAggregations aggregations
+        ) {
             this.docCount = docCount;
             this.centroid = centroid;
             this.aggregations = aggregations;
@@ -54,10 +60,13 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
         private Bucket(StreamInput in) throws IOException {
             hashAsLong = in.readLong();
             docCount = in.readVLong();
-            final long hash = in.readLong();
-            centroid = new GeoPoint(decodeLatitude(hash), decodeLongitude(hash));
+            double lat = in.readDouble();
+            double lon = in.readDouble();
+            centroid = new GeoPoint(lat, lon);
             visited = in.readBoolean();
             aggregations = InternalAggregations.readFrom(in);
+            geohashesList = new HashSet<>();
+            geohashesList.add(hashAsLong);
         }
 
         /**
@@ -67,7 +76,8 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
         public void writeTo(StreamOutput out) throws IOException {
             out.writeLong(hashAsLong);
             out.writeVLong(docCount);
-            out.writeLong(encodeLatLon(centroid.lat(), centroid.lon()));
+            out.writeDouble(centroid.lat());
+            out.writeDouble(centroid.lon());
             out.writeBoolean(visited);
             aggregations.writeTo(out);
         }
@@ -104,9 +114,18 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
             return Long.compare(this.hashAsLong, other.hashAsLong);
         }
 
-        final void bucketToXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        final void bucketToXContent(
+            XContentBuilder builder,
+            ToXContent.Params params
+        ) throws IOException {
             builder.startObject();
-            builder.field("geohash_grids", geohashesList.stream().map(Geohash::stringEncode).collect(Collectors.toList()));
+            builder.field(
+                "geohash_grids",
+                geohashesList
+                    .stream()
+                    .map(Geohash::stringEncode)
+                    .collect(Collectors.toList())
+            );
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             builder.field("centroid", centroid);
             aggregations.toXContentInternal(builder, params);
@@ -118,14 +137,17 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Bucket bucket = (Bucket) o;
-            return hashAsLong == bucket.hashAsLong && docCount == bucket.docCount && Objects.equals(aggregations, bucket.aggregations);
+            return (
+                hashAsLong == bucket.hashAsLong &&
+                docCount == bucket.docCount &&
+                Objects.equals(aggregations, bucket.aggregations)
+            );
         }
 
         @Override
         public int hashCode() {
             return Objects.hash(hashAsLong, docCount, aggregations);
         }
-
     }
 
     private final double radius;
@@ -170,20 +192,6 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
         out.writeCollection((Collection<? extends Writeable>) buckets);
     }
 
-    public static long encodeLatLon(double lat, double lon) {
-        return (Integer.toUnsignedLong(GeoEncodingUtils.encodeLatitude(lat)) << 32) | Integer.toUnsignedLong(
-            GeoEncodingUtils.encodeLongitude(lon)
-        );
-    }
-
-    public static double decodeLatitude(long encodedLatLon) {
-        return GeoEncodingUtils.decodeLatitude((int) (encodedLatLon >>> 32));
-    }
-
-    public static double decodeLongitude(long encodedLatLon) {
-        return GeoEncodingUtils.decodeLongitude((int) (encodedLatLon & 0xFFFFFFFFL));
-    }
-
     protected Reader<Bucket> getBucketReader() {
         return Bucket::new;
     }
@@ -195,16 +203,36 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
 
     @Override
     public InternalGeoPointClustering create(List<Bucket> buckets) {
-        return new InternalGeoPointClustering(this.name, this.radius, this.ratio, this.requiredSize, buckets, this.metadata);
+        return new InternalGeoPointClustering(
+            this.name,
+            this.radius,
+            this.ratio,
+            this.requiredSize,
+            buckets,
+            this.metadata
+        );
     }
 
-    public Bucket createBucket(long hashAsLong, GeoPoint centroid, long docCount, InternalAggregations aggregations) {
+    public Bucket createBucket(
+        long hashAsLong,
+        GeoPoint centroid,
+        long docCount,
+        InternalAggregations aggregations
+    ) {
         return new Bucket(hashAsLong, centroid, docCount, aggregations);
     }
 
     @Override
-    public Bucket createBucket(InternalAggregations aggregations, Bucket prototype) {
-        return new Bucket(prototype.hashAsLong, prototype.centroid, prototype.docCount, aggregations);
+    public Bucket createBucket(
+        InternalAggregations aggregations,
+        Bucket prototype
+    ) {
+        return new Bucket(
+            prototype.hashAsLong,
+            prototype.centroid,
+            prototype.docCount,
+            aggregations
+        );
     }
 
     @Override
@@ -222,7 +250,10 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
      * @param context           The aggregation reduce context for reducing internal aggregations.
      * @return A list of merged buckets representing the final clusters.
      */
-    private List<Bucket> mergeBuckets(Bucket[] candidateClusters, AggregationReduceContext context) {
+    private List<Bucket> mergeBuckets(
+        Bucket[] candidateClusters,
+        AggregationReduceContext context
+    ) {
         List<Bucket> finalClusters = new ArrayList<>();
         for (Bucket bucket : candidateClusters) {
             if (bucket.visited) {
@@ -252,10 +283,13 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
      * This reducer is used during the reduction phase of the multi-bucket aggregation GeoPointClustering.
      */
     @Override
-    protected AggregatorReducer getLeaderReducer(AggregationReduceContext context, int size) {
+    protected AggregatorReducer getLeaderReducer(
+        AggregationReduceContext context,
+        int size
+    ) {
         return new AggregatorReducer() {
-
-            final LongObjectPagedHashMap<BucketReducer> bucketsReducer = new LongObjectPagedHashMap<>(size, context.bigArrays());
+            final LongObjectPagedHashMap<BucketReducer> bucketsReducer =
+                new LongObjectPagedHashMap<>(size, context.bigArrays());
 
             /**
              * Accepts a partial aggregation result from a shard and accumulates its buckets into the corresponding reducers.
@@ -269,9 +303,12 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
              */
             @Override
             public void accept(InternalAggregation aggregation) {
-                final InternalGeoPointClustering grid = (InternalGeoPointClustering) aggregation;
+                final InternalGeoPointClustering grid =
+                    (InternalGeoPointClustering) aggregation;
                 for (Bucket bucket : grid.getBuckets()) {
-                    BucketReducer reducer = bucketsReducer.get(bucket.hashAsLong);
+                    BucketReducer reducer = bucketsReducer.get(
+                        bucket.hashAsLong
+                    );
                     if (reducer == null) {
                         reducer = new BucketReducer(bucket, context, size);
                         bucketsReducer.put(bucket.hashAsLong, reducer);
@@ -289,14 +326,28 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
             public InternalAggregation get() {
                 if (buckets == null) {
                     // If no buckets were collected, return an empty aggregation
-                    return new InternalGeoPointClustering(getName(), radius, ratio, requiredSize, Collections.emptyList(), getMetadata());
+                    return new InternalGeoPointClustering(
+                        getName(),
+                        radius,
+                        ratio,
+                        requiredSize,
+                        Collections.emptyList(),
+                        getMetadata()
+                    );
                 }
 
                 final int size = Math.toIntExact(
-                    context.isFinalReduce() == false ? bucketsReducer.size() : Math.min(requiredSize, bucketsReducer.size())
+                    context.isFinalReduce() == false
+                        ? bucketsReducer.size()
+                        : Math.min(requiredSize, bucketsReducer.size())
                 );
                 try (
-                    BucketPriorityQueue<Bucket, Bucket> ordered = new BucketPriorityQueue<>(size, context.bigArrays(), Function.identity())
+                    BucketPriorityQueue<Bucket, Bucket> ordered =
+                        new BucketPriorityQueue<>(
+                            size,
+                            context.bigArrays(),
+                            Function.identity()
+                        )
                 ) {
                     // Populate the priority queue with the reduced clusters
                     bucketsReducer.forEach(entry -> {
@@ -312,7 +363,10 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
                     for (int i = (int) ordered.size() - 1; i >= 0; i--) {
                         clusters[i] = ordered.pop();
                     }
-                    List<Bucket> finalClusters = mergeBuckets(clusters, context);
+                    List<Bucket> finalClusters = mergeBuckets(
+                        clusters,
+                        context
+                    );
                     context.consumeBucketsAndMaybeBreak(finalClusters.size());
                     return create(finalClusters);
                 }
@@ -337,15 +391,21 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
      * @return A new InternalAggregation with scaled doc counts and finalized sub-aggregations.
      */
     @Override
-    public InternalAggregation finalizeSampling(SamplingContext samplingContext) {
+    public InternalAggregation finalizeSampling(
+        SamplingContext samplingContext
+    ) {
         return create(
-            buckets.stream()
-                .<Bucket>map(
-                    b -> this.createBucket(
+            buckets
+                .stream()
+                .<Bucket>map(b ->
+                    this.createBucket(
                         b.hashAsLong,
                         b.centroid,
                         samplingContext.scaleUp(b.docCount),
-                        InternalAggregations.finalizeSampling(b.aggregations, samplingContext)
+                        InternalAggregations.finalizeSampling(
+                            b.aggregations,
+                            samplingContext
+                        )
                     )
                 )
                 .toList()
@@ -363,7 +423,12 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
      * @param revisit          A list of buckets to potentially revisit for merging.
      * @param reduceContext    Context used to reduce internal aggregations during merging.
      */
-    private void computeDistance(Bucket bucket, Bucket potentialNeighbor, List<Bucket> revisit, AggregationReduceContext reduceContext) {
+    private void computeDistance(
+        Bucket bucket,
+        Bucket potentialNeighbor,
+        List<Bucket> revisit,
+        AggregationReduceContext reduceContext
+    ) {
         // Skip if this neighbor has already been processed
         if (potentialNeighbor.visited) {
             return;
@@ -378,7 +443,8 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
         );
 
         // Calculate average latitude to adjust radius based on Earth's curvature
-        double avgLat = (bucket.centroid.lat() + potentialNeighbor.centroid.lat()) / 2;
+        double avgLat =
+            (bucket.centroid.lat() + potentialNeighbor.centroid.lat()) / 2;
 
         // Apply latitude correction to the fixed clustering radius
         double fixedRadius = radius * Math.cos(Math.toRadians(avgLat));
@@ -392,10 +458,16 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
             long mergedDocCount = bucket.docCount + potentialNeighbor.docCount;
 
             // Compute new weighted centroid
-            double newCentroidLat = (bucket.centroid.getLat() * bucket.docCount + potentialNeighbor.centroid.getLat()
-                * potentialNeighbor.docCount) / mergedDocCount;
-            double newCentroidLon = (bucket.centroid.getLon() * bucket.docCount + potentialNeighbor.centroid.getLon()
-                * potentialNeighbor.docCount) / mergedDocCount;
+            double newCentroidLat =
+                (bucket.centroid.getLat() * bucket.docCount +
+                    potentialNeighbor.centroid.getLat() *
+                    potentialNeighbor.docCount) /
+                mergedDocCount;
+            double newCentroidLon =
+                (bucket.centroid.getLon() * bucket.docCount +
+                    potentialNeighbor.centroid.getLon() *
+                    potentialNeighbor.docCount) /
+                mergedDocCount;
             bucket.centroid = new GeoPoint(newCentroidLat, newCentroidLon);
 
             // Update document count and reduce sub-aggregations
@@ -403,19 +475,29 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
             List<InternalAggregations> aggregationsList = new ArrayList<>();
             aggregationsList.add(bucket.aggregations);
             aggregationsList.add(potentialNeighbor.aggregations);
-            bucket.aggregations = InternalAggregations.reduce(aggregationsList, reduceContext);
+            bucket.aggregations = InternalAggregations.reduce(
+                aggregationsList,
+                reduceContext
+            );
 
             // Track the geohash of the merged neighbor
             bucket.geohashesList.add(potentialNeighbor.hashAsLong);
         }
         // If not merged, check if it should be revisited later
-        else if (revisit != null && ratio > 0 && neighborDistance / fixedRadius < ratio) {
+        else if (
+            revisit != null &&
+            ratio > 0 &&
+            neighborDistance / fixedRadius < ratio
+        ) {
             revisit.add(potentialNeighbor);
         }
     }
 
     @Override
-    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+    public XContentBuilder doXContentBody(
+        XContentBuilder builder,
+        Params params
+    ) throws IOException {
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (Bucket bucket : buckets) {
             bucket.bucketToXContent(builder, params);
@@ -432,14 +514,22 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
     @Override
     public boolean equals(Object obj) {
         InternalGeoPointClustering other = (InternalGeoPointClustering) obj;
-        return Objects.equals(requiredSize, other.requiredSize) && Objects.equals(buckets, other.buckets);
+        return (
+            Objects.equals(requiredSize, other.requiredSize) &&
+            Objects.equals(buckets, other.buckets)
+        );
     }
 
-    static class BucketPriorityQueue<A, B extends Bucket> extends ObjectArrayPriorityQueue<A> {
+    static class BucketPriorityQueue<A, B extends Bucket>
+        extends ObjectArrayPriorityQueue<A> {
 
         private final Function<A, B> bucketSupplier;
 
-        BucketPriorityQueue(int size, BigArrays bigArrays, Function<A, B> bucketSupplier) {
+        BucketPriorityQueue(
+            int size,
+            BigArrays bigArrays,
+            Function<A, B> bucketSupplier
+        ) {
             super(size, bigArrays);
             this.bucketSupplier = bucketSupplier;
         }
@@ -452,7 +542,9 @@ public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
             if (cmp == 0) {
                 cmp = b2.compareTo(b1);
                 if (cmp == 0) {
-                    cmp = System.identityHashCode(o2) - System.identityHashCode(o1);
+                    cmp =
+                        System.identityHashCode(o2) -
+                        System.identityHashCode(o1);
                 }
             }
             return cmp > 0;

--- a/src/main/java/com/opendatasoft/elasticsearch/search/aggregations/bucket/geopointclustering/InternalGeoPointClustering.java
+++ b/src/main/java/com/opendatasoft/elasticsearch/search/aggregations/bucket/geopointclustering/InternalGeoPointClustering.java
@@ -1,12 +1,5 @@
 package com.opendatasoft.elasticsearch.search.aggregations.bucket.geopointclustering;
 
-import static java.util.Collections.unmodifiableList;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -22,16 +15,21 @@ import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
-public class InternalGeoPointClustering
-    extends InternalMultiBucketAggregation<
-        InternalGeoPointClustering,
-        InternalGeoPointClustering.Bucket
-    >
-    implements GeoPointClustering {
+import java.io.IOException;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
-    static class Bucket
-        extends InternalMultiBucketAggregation.InternalBucketWritable
-        implements GeoPointClustering.Bucket, Comparable<Bucket> {
+import static java.util.Collections.unmodifiableList;
+
+public class InternalGeoPointClustering extends InternalMultiBucketAggregation<
+    InternalGeoPointClustering,
+    InternalGeoPointClustering.Bucket> implements GeoPointClustering {
+
+    static class Bucket extends InternalMultiBucketAggregation.InternalBucketWritable
+        implements
+            GeoPointClustering.Bucket,
+            Comparable<Bucket> {
 
         protected long hashAsLong;
         protected GeoPoint centroid;
@@ -40,12 +38,7 @@ public class InternalGeoPointClustering
         protected boolean visited = false;
         protected Set<Long> geohashesList;
 
-        Bucket(
-            long hashAsLong,
-            GeoPoint centroid,
-            long docCount,
-            InternalAggregations aggregations
-        ) {
+        Bucket(long hashAsLong, GeoPoint centroid, long docCount, InternalAggregations aggregations) {
             this.docCount = docCount;
             this.centroid = centroid;
             this.aggregations = aggregations;
@@ -114,18 +107,9 @@ public class InternalGeoPointClustering
             return Long.compare(this.hashAsLong, other.hashAsLong);
         }
 
-        final void bucketToXContent(
-            XContentBuilder builder,
-            ToXContent.Params params
-        ) throws IOException {
+        final void bucketToXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
             builder.startObject();
-            builder.field(
-                "geohash_grids",
-                geohashesList
-                    .stream()
-                    .map(Geohash::stringEncode)
-                    .collect(Collectors.toList())
-            );
+            builder.field("geohash_grids", geohashesList.stream().map(Geohash::stringEncode).collect(Collectors.toList()));
             builder.field(CommonFields.DOC_COUNT.getPreferredName(), docCount);
             builder.field("centroid", centroid);
             aggregations.toXContentInternal(builder, params);
@@ -137,11 +121,7 @@ public class InternalGeoPointClustering
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Bucket bucket = (Bucket) o;
-            return (
-                hashAsLong == bucket.hashAsLong &&
-                docCount == bucket.docCount &&
-                Objects.equals(aggregations, bucket.aggregations)
-            );
+            return (hashAsLong == bucket.hashAsLong && docCount == bucket.docCount && Objects.equals(aggregations, bucket.aggregations));
         }
 
         @Override
@@ -203,36 +183,16 @@ public class InternalGeoPointClustering
 
     @Override
     public InternalGeoPointClustering create(List<Bucket> buckets) {
-        return new InternalGeoPointClustering(
-            this.name,
-            this.radius,
-            this.ratio,
-            this.requiredSize,
-            buckets,
-            this.metadata
-        );
+        return new InternalGeoPointClustering(this.name, this.radius, this.ratio, this.requiredSize, buckets, this.metadata);
     }
 
-    public Bucket createBucket(
-        long hashAsLong,
-        GeoPoint centroid,
-        long docCount,
-        InternalAggregations aggregations
-    ) {
+    public Bucket createBucket(long hashAsLong, GeoPoint centroid, long docCount, InternalAggregations aggregations) {
         return new Bucket(hashAsLong, centroid, docCount, aggregations);
     }
 
     @Override
-    public Bucket createBucket(
-        InternalAggregations aggregations,
-        Bucket prototype
-    ) {
-        return new Bucket(
-            prototype.hashAsLong,
-            prototype.centroid,
-            prototype.docCount,
-            aggregations
-        );
+    public Bucket createBucket(InternalAggregations aggregations, Bucket prototype) {
+        return new Bucket(prototype.hashAsLong, prototype.centroid, prototype.docCount, aggregations);
     }
 
     @Override
@@ -250,10 +210,7 @@ public class InternalGeoPointClustering
      * @param context           The aggregation reduce context for reducing internal aggregations.
      * @return A list of merged buckets representing the final clusters.
      */
-    private List<Bucket> mergeBuckets(
-        Bucket[] candidateClusters,
-        AggregationReduceContext context
-    ) {
+    private List<Bucket> mergeBuckets(Bucket[] candidateClusters, AggregationReduceContext context) {
         List<Bucket> finalClusters = new ArrayList<>();
         for (Bucket bucket : candidateClusters) {
             if (bucket.visited) {
@@ -283,13 +240,9 @@ public class InternalGeoPointClustering
      * This reducer is used during the reduction phase of the multi-bucket aggregation GeoPointClustering.
      */
     @Override
-    protected AggregatorReducer getLeaderReducer(
-        AggregationReduceContext context,
-        int size
-    ) {
+    protected AggregatorReducer getLeaderReducer(AggregationReduceContext context, int size) {
         return new AggregatorReducer() {
-            final LongObjectPagedHashMap<BucketReducer> bucketsReducer =
-                new LongObjectPagedHashMap<>(size, context.bigArrays());
+            final LongObjectPagedHashMap<BucketReducer> bucketsReducer = new LongObjectPagedHashMap<>(size, context.bigArrays());
 
             /**
              * Accepts a partial aggregation result from a shard and accumulates its buckets into the corresponding reducers.
@@ -303,12 +256,9 @@ public class InternalGeoPointClustering
              */
             @Override
             public void accept(InternalAggregation aggregation) {
-                final InternalGeoPointClustering grid =
-                    (InternalGeoPointClustering) aggregation;
+                final InternalGeoPointClustering grid = (InternalGeoPointClustering) aggregation;
                 for (Bucket bucket : grid.getBuckets()) {
-                    BucketReducer reducer = bucketsReducer.get(
-                        bucket.hashAsLong
-                    );
+                    BucketReducer reducer = bucketsReducer.get(bucket.hashAsLong);
                     if (reducer == null) {
                         reducer = new BucketReducer(bucket, context, size);
                         bucketsReducer.put(bucket.hashAsLong, reducer);
@@ -326,28 +276,14 @@ public class InternalGeoPointClustering
             public InternalAggregation get() {
                 if (buckets == null) {
                     // If no buckets were collected, return an empty aggregation
-                    return new InternalGeoPointClustering(
-                        getName(),
-                        radius,
-                        ratio,
-                        requiredSize,
-                        Collections.emptyList(),
-                        getMetadata()
-                    );
+                    return new InternalGeoPointClustering(getName(), radius, ratio, requiredSize, Collections.emptyList(), getMetadata());
                 }
 
                 final int size = Math.toIntExact(
-                    context.isFinalReduce() == false
-                        ? bucketsReducer.size()
-                        : Math.min(requiredSize, bucketsReducer.size())
+                    context.isFinalReduce() == false ? bucketsReducer.size() : Math.min(requiredSize, bucketsReducer.size())
                 );
                 try (
-                    BucketPriorityQueue<Bucket, Bucket> ordered =
-                        new BucketPriorityQueue<>(
-                            size,
-                            context.bigArrays(),
-                            Function.identity()
-                        )
+                    BucketPriorityQueue<Bucket, Bucket> ordered = new BucketPriorityQueue<>(size, context.bigArrays(), Function.identity())
                 ) {
                     // Populate the priority queue with the reduced clusters
                     bucketsReducer.forEach(entry -> {
@@ -363,10 +299,7 @@ public class InternalGeoPointClustering
                     for (int i = (int) ordered.size() - 1; i >= 0; i--) {
                         clusters[i] = ordered.pop();
                     }
-                    List<Bucket> finalClusters = mergeBuckets(
-                        clusters,
-                        context
-                    );
+                    List<Bucket> finalClusters = mergeBuckets(clusters, context);
                     context.consumeBucketsAndMaybeBreak(finalClusters.size());
                     return create(finalClusters);
                 }
@@ -391,21 +324,15 @@ public class InternalGeoPointClustering
      * @return A new InternalAggregation with scaled doc counts and finalized sub-aggregations.
      */
     @Override
-    public InternalAggregation finalizeSampling(
-        SamplingContext samplingContext
-    ) {
+    public InternalAggregation finalizeSampling(SamplingContext samplingContext) {
         return create(
-            buckets
-                .stream()
-                .<Bucket>map(b ->
-                    this.createBucket(
+            buckets.stream()
+                .<Bucket>map(
+                    b -> this.createBucket(
                         b.hashAsLong,
                         b.centroid,
                         samplingContext.scaleUp(b.docCount),
-                        InternalAggregations.finalizeSampling(
-                            b.aggregations,
-                            samplingContext
-                        )
+                        InternalAggregations.finalizeSampling(b.aggregations, samplingContext)
                     )
                 )
                 .toList()
@@ -423,12 +350,7 @@ public class InternalGeoPointClustering
      * @param revisit          A list of buckets to potentially revisit for merging.
      * @param reduceContext    Context used to reduce internal aggregations during merging.
      */
-    private void computeDistance(
-        Bucket bucket,
-        Bucket potentialNeighbor,
-        List<Bucket> revisit,
-        AggregationReduceContext reduceContext
-    ) {
+    private void computeDistance(Bucket bucket, Bucket potentialNeighbor, List<Bucket> revisit, AggregationReduceContext reduceContext) {
         // Skip if this neighbor has already been processed
         if (potentialNeighbor.visited) {
             return;
@@ -443,8 +365,7 @@ public class InternalGeoPointClustering
         );
 
         // Calculate average latitude to adjust radius based on Earth's curvature
-        double avgLat =
-            (bucket.centroid.lat() + potentialNeighbor.centroid.lat()) / 2;
+        double avgLat = (bucket.centroid.lat() + potentialNeighbor.centroid.lat()) / 2;
 
         // Apply latitude correction to the fixed clustering radius
         double fixedRadius = radius * Math.cos(Math.toRadians(avgLat));
@@ -458,16 +379,10 @@ public class InternalGeoPointClustering
             long mergedDocCount = bucket.docCount + potentialNeighbor.docCount;
 
             // Compute new weighted centroid
-            double newCentroidLat =
-                (bucket.centroid.getLat() * bucket.docCount +
-                    potentialNeighbor.centroid.getLat() *
-                    potentialNeighbor.docCount) /
-                mergedDocCount;
-            double newCentroidLon =
-                (bucket.centroid.getLon() * bucket.docCount +
-                    potentialNeighbor.centroid.getLon() *
-                    potentialNeighbor.docCount) /
-                mergedDocCount;
+            double newCentroidLat = (bucket.centroid.getLat() * bucket.docCount + potentialNeighbor.centroid.getLat()
+                * potentialNeighbor.docCount) / mergedDocCount;
+            double newCentroidLon = (bucket.centroid.getLon() * bucket.docCount + potentialNeighbor.centroid.getLon()
+                * potentialNeighbor.docCount) / mergedDocCount;
             bucket.centroid = new GeoPoint(newCentroidLat, newCentroidLon);
 
             // Update document count and reduce sub-aggregations
@@ -475,29 +390,19 @@ public class InternalGeoPointClustering
             List<InternalAggregations> aggregationsList = new ArrayList<>();
             aggregationsList.add(bucket.aggregations);
             aggregationsList.add(potentialNeighbor.aggregations);
-            bucket.aggregations = InternalAggregations.reduce(
-                aggregationsList,
-                reduceContext
-            );
+            bucket.aggregations = InternalAggregations.reduce(aggregationsList, reduceContext);
 
             // Track the geohash of the merged neighbor
             bucket.geohashesList.add(potentialNeighbor.hashAsLong);
         }
         // If not merged, check if it should be revisited later
-        else if (
-            revisit != null &&
-            ratio > 0 &&
-            neighborDistance / fixedRadius < ratio
-        ) {
+        else if (revisit != null && ratio > 0 && neighborDistance / fixedRadius < ratio) {
             revisit.add(potentialNeighbor);
         }
     }
 
     @Override
-    public XContentBuilder doXContentBody(
-        XContentBuilder builder,
-        Params params
-    ) throws IOException {
+    public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
         for (Bucket bucket : buckets) {
             bucket.bucketToXContent(builder, params);
@@ -514,22 +419,14 @@ public class InternalGeoPointClustering
     @Override
     public boolean equals(Object obj) {
         InternalGeoPointClustering other = (InternalGeoPointClustering) obj;
-        return (
-            Objects.equals(requiredSize, other.requiredSize) &&
-            Objects.equals(buckets, other.buckets)
-        );
+        return (Objects.equals(requiredSize, other.requiredSize) && Objects.equals(buckets, other.buckets));
     }
 
-    static class BucketPriorityQueue<A, B extends Bucket>
-        extends ObjectArrayPriorityQueue<A> {
+    static class BucketPriorityQueue<A, B extends Bucket> extends ObjectArrayPriorityQueue<A> {
 
         private final Function<A, B> bucketSupplier;
 
-        BucketPriorityQueue(
-            int size,
-            BigArrays bigArrays,
-            Function<A, B> bucketSupplier
-        ) {
+        BucketPriorityQueue(int size, BigArrays bigArrays, Function<A, B> bucketSupplier) {
             super(size, bigArrays);
             this.bucketSupplier = bucketSupplier;
         }
@@ -542,9 +439,7 @@ public class InternalGeoPointClustering
             if (cmp == 0) {
                 cmp = b2.compareTo(b1);
                 if (cmp == 0) {
-                    cmp =
-                        System.identityHashCode(o2) -
-                        System.identityHashCode(o1);
+                    cmp = System.identityHashCode(o2) - System.identityHashCode(o1);
                 }
             }
             return cmp > 0;

--- a/src/yamlRestTest/resources/rest-api-spec/test/GeoPointClusteringAggregation/20_geo_clustering.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/GeoPointClusteringAggregation/20_geo_clustering.yml
@@ -125,31 +125,6 @@ setup:
         body: {"aggs": { "gc" : { "geo_point_clustering": {"field": "point", "zoom": 1} } } }
 
 
-  - match: { hits.total: 15 }
-  - length: { aggregations.gc.buckets: 1 }
-  - match: { aggregations.gc.buckets.0.doc_count: 15 }
-  - match: { aggregations.gc.buckets.0.centroid.lat: 48.8468417795375 }
-  - match: { aggregations.gc.buckets.0.centroid.lon: 2.331401154398918 }
-  # Trigger the cache, the values should not have change
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        index: test
-        body:
-          {
-            "aggs":
-              {
-                "gc":
-                  { "geo_point_clustering": { "field": "point", "zoom": 1 } },
-              },
-          }
-  - match: { hits.total: 15 }
-  - length: { aggregations.gc.buckets: 1 }
-  - match: { aggregations.gc.buckets.0.doc_count: 15 }
-  - match: { aggregations.gc.buckets.0.centroid.lat: 48.8468417795375 }
-  - match: { aggregations.gc.buckets.0.centroid.lon: 2.331401154398918 }
-
-
 ---
 
 "Test Zoom 9":
@@ -296,3 +271,73 @@ setup:
 
   - gte: { hits.total: 1 }
   - length: { aggregations.gc.buckets: 1 }
+
+---
+"Test that the cache is working":
+  - do:
+      indices.create:
+        index: test_cache_index
+        body:
+          settings:
+            number_of_shards: 1
+          mappings:
+            "properties":
+              "point":
+                "type": "geo_point"
+
+  - do:
+      index:
+        index: test_cache_index
+        id: 1
+        body: { "point": [2.253588, 48.864682] }
+
+  - do:
+      index:
+        index: test_cache_index
+        id: 2
+        body: { "point": [2.336643, 48.822493] }
+
+  - do:
+      index:
+        index: test_cache_index
+        id: 3
+        body: { "point": [2.438465, 48.84204] }
+
+  - do:
+      indices.refresh:
+        index: test_cache_index
+
+  - do:
+      search:
+        index: test_cache_index
+        request_cache: true
+        body:
+          size: 0
+          aggs:
+            gc:
+              geo_point_clustering:
+                field: point
+                zoom: 1
+
+  - length: { aggregations.gc.buckets: 1 }
+  - match: { aggregations.gc.buckets.0.doc_count: 3 }
+  - match: { aggregations.gc.buckets.0.centroid.lat: 48.84307164698839 }
+  - match: { aggregations.gc.buckets.0.centroid.lon: 2.3428986221551895 }
+
+  # Second strictly identical agg is hitting the cache
+  - do:
+      search:
+        index: test_cache_index
+        request_cache: true
+        body:
+          size: 0
+          aggs:
+            gc:
+              geo_point_clustering:
+                field: point
+                zoom: 1
+
+  - length: { aggregations.gc.buckets: 1 }
+  - match: { aggregations.gc.buckets.0.doc_count: 3 }
+  - match: { aggregations.gc.buckets.0.centroid.lat: 48.84307164698839 }
+  - match: { aggregations.gc.buckets.0.centroid.lon: 2.3428986221551895 }

--- a/src/yamlRestTest/resources/rest-api-spec/test/GeoPointClusteringAggregation/20_geo_clustering.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/GeoPointClusteringAggregation/20_geo_clustering.yml
@@ -130,6 +130,24 @@ setup:
   - match: { aggregations.gc.buckets.0.doc_count: 15 }
   - match: { aggregations.gc.buckets.0.centroid.lat: 48.8468417795375 }
   - match: { aggregations.gc.buckets.0.centroid.lon: 2.331401154398918 }
+  # Trigger the cache, the values should not have change
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          {
+            "aggs":
+              {
+                "gc":
+                  { "geo_point_clustering": { "field": "point", "zoom": 1 } },
+              },
+          }
+  - match: { hits.total: 15 }
+  - length: { aggregations.gc.buckets: 1 }
+  - match: { aggregations.gc.buckets.0.doc_count: 15 }
+  - match: { aggregations.gc.buckets.0.centroid.lat: 48.8468417795375 }
+  - match: { aggregations.gc.buckets.0.centroid.lon: 2.331401154398918 }
 
 
 ---

--- a/src/yamlRestTest/resources/rest-api-spec/test/GeoPointClusteringAggregation/20_geo_clustering.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/GeoPointClusteringAggregation/20_geo_clustering.yml
@@ -124,6 +124,11 @@ setup:
         index: test
         body: {"aggs": { "gc" : { "geo_point_clustering": {"field": "point", "zoom": 1} } } }
 
+  - match: { hits.total: 15 }
+  - length: { aggregations.gc.buckets: 1 }
+  - match: { aggregations.gc.buckets.0.doc_count: 15 }
+  - match: { aggregations.gc.buckets.0.centroid.lat: 48.8468417795375 }
+  - match: { aggregations.gc.buckets.0.centroid.lon: 2.331401154398918 }
 
 ---
 


### PR DESCRIPTION
## Summary

The fix avoids loss precision when the data is coming from the cache. 
Because we read the centroid as 2 long values and cast it as double in the GeoPoint. 